### PR TITLE
Add error handling for refused connections.

### DIFF
--- a/corsy.py
+++ b/corsy.py
@@ -4,6 +4,7 @@
 import sys
 import json
 import argparse
+from requests.exceptions import ConnectionError
 
 from core.tests import active_tests
 from core.utils import host, prompt, format_result, extractHeaders, create_url_list
@@ -63,7 +64,10 @@ def cors(target, header_dict, delay):
     netloc = parsed.netloc
     scheme = parsed.scheme
     url = scheme + '://' + netloc
-    return active_tests(url, root, scheme, header_dict, delay)
+    try:
+        return active_tests(url, root, scheme, header_dict, delay)
+    except ConnectionError as exc:
+        print(f'[WARNING] Unable to connect to {target}: {exc}')
 
 
 if urls:


### PR DESCRIPTION
This will allow the tool to continue testing if one or more of the target URLS refuses a connection. Previously, this would cause the tool to error out once it encountered a URL that refused a connection.

I would also understand if you wanted to make this a boolean flag, and I could code that up. I also don't know how you would prefer the output to look like (I used a generic format) so that can also be altered to keep with the style of the tool.

This tool is awesome and I use it all the time, and I really appreciate all the tools you open-source. Hopefully this small way of giving back can help pay it forward :)