### PR TITLE
Add skip_wildcard flag to skip wild card origin test

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ Using Corsy is pretty simple
 ##### Skip printing tips
 `-q` can be used to skip printing of `description`, `severity`, `exploitation` fields in the output.
 
+##### Skip wildcard test
+Since wild card origin can't be used to exploitation `--skip-wildcard` can be used to skip printing of wildcard origin output. 
+
 ### Tests implemented
 - Pre-domain bypass
 - Post-domain bypass

--- a/core/tests.py
+++ b/core/tests.py
@@ -6,10 +6,10 @@ from core.utils import host, load_json
 
 details = load_json(sys.path[0] + '/db/details.json')
 
-def passive_tests(url, headers):
+def passive_tests(url, headers, skip_wildcard):
     root = host(url)
     acao_header, acac_header = headers.get('access-control-allow-origin', None), headers.get('access-control-allow-credentials', None)
-    if acao_header == '*':
+    if acao_header == '*' and not skip_wildcard:
         info = details['wildcard value']
         info['acao header'] = acao_header
         info['acac header'] = acac_header
@@ -22,7 +22,7 @@ def passive_tests(url, headers):
             return {url : info}
 
 
-def active_tests(url, root, scheme, header_dict, delay):
+def active_tests(url, root, scheme, header_dict, delay, skip_wildcard):
     origin = scheme + '://' + root
     headers = requester(url, scheme, header_dict, origin)
     acao_header, acac_header = headers.get('access-control-allow-origin', None), headers.get('access-control-allow-credentials', None)
@@ -108,4 +108,4 @@ def active_tests(url, root, scheme, header_dict, delay):
         info['acac header'] = acac_header
         return {url : info}
     else:
-        return passive_tests(url, headers)
+        return passive_tests(url, headers, skip_wildcard)

--- a/core/tests.py
+++ b/core/tests.py
@@ -6,7 +6,7 @@ from core.utils import host, load_json
 
 details = load_json(sys.path[0] + '/db/details.json')
 
-def passive_tests(url, headers, skip_wildcard):
+def passive_tests(url, headers, skip_wildcard = False):
     root = host(url)
     acao_header, acac_header = headers.get('access-control-allow-origin', None), headers.get('access-control-allow-credentials', None)
     if acao_header == '*' and not skip_wildcard:
@@ -22,7 +22,7 @@ def passive_tests(url, headers, skip_wildcard):
             return {url : info}
 
 
-def active_tests(url, root, scheme, header_dict, delay, skip_wildcard):
+def active_tests(url, root, scheme, header_dict, delay, skip_wildcard = False):
     origin = scheme + '://' + root
     headers = requester(url, scheme, header_dict, origin)
     acao_header, acac_header = headers.get('access-control-allow-origin', None), headers.get('access-control-allow-credentials', None)

--- a/corsy.py
+++ b/corsy.py
@@ -65,7 +65,7 @@ else:
     urls = create_stdin_list(target, sys.stdin)
 
 
-def cors(target, header_dict, delay, skip_wildcard):
+def cors(target, header_dict, delay, skip_wildcard = False):
     url = target
     root = host(url)
     parsed = urlparse(url)


### PR DESCRIPTION
Since wild card origins can't be exploited in 99% of cases, it pollute the tool output. This pull request adds an optional flag called `skip_wildcard` that skips wild card origin check and only output exploitable cases.  