### PR TITLE
fix: prevent thread freeze on unresponsive hosts

### DIFF
--- a/core/requester.py
+++ b/core/requester.py
@@ -10,11 +10,13 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 def requester(url, scheme, headers, origin):
     headers['Origin'] = origin
     try:
-        response = requests.get(url, headers=headers, verify=False)
+        response = requests.get(url, headers=headers, verify=False, timeout=10)
         headers = response.headers
         for key, value in headers.items():
             if key.lower() == 'access-control-allow-origin':
                 return headers
+    except requests.exceptions.Timeout:
+        pass
     except requests.exceptions.RequestException as e:
         if 'Failed to establish a new connection' in str(e):
             print ('%s %s is unreachable' % (bad, url))

--- a/corsy.py
+++ b/corsy.py
@@ -82,7 +82,13 @@ if urls:
     threadpool = concurrent.futures.ThreadPoolExecutor(max_workers=threads)
     futures = (threadpool.submit(cors, url, header_dict, delay) for url in urls)
     for each in concurrent.futures.as_completed(futures):
-        result = each.result()
+        try:
+            result = each.result(timeout=15)
+        except concurrent.futures.TimeoutError:
+            print(' %s A thread timed out, skipping.' % bad)
+            continue
+        except ConnectionError as exc:
+            continue
         results.append(result)
         if result:
             for i in result:


### PR DESCRIPTION
core/requester.py
- add timeout=10 to requests.get() — without it, threads hung indefinitely on hosts that accept the TCP connection but never send a response (internal/firewalled endpoints)
- add explicit except Timeout before the broad RequestException handler so silent hangs are caught and skipped cleanly

corsy.py
- wrap each.result() with timeout=15 and catch TimeoutError — even if requester() somehow stalls past its own deadline, the future is now forcibly abandoned and the scan continues
